### PR TITLE
Deploy to ~/mne-python_VERSION on macOS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Check installation (macOS)
         if: ${{ runner.os == 'macOS' }}
         run: |
-          source ~/mne-python/bin/activate
+          source ~/mne-python_0.24.1/bin/activate
           conda info
           mamba list
           mne sys_info

--- a/recipes/mne-python_0.24/construct.yaml
+++ b/recipes/mne-python_0.24/construct.yaml
@@ -1,4 +1,5 @@
-name: MNE-Python
+name: MNE-Python         # [not osx]
+name: MNE-Python_0.24.1  # [osx]
 version: 0.24.1_installer-2022.2
 company: MNE-Python Developers
 


### PR DESCRIPTION
It's not directly possible to deploy to `~/mne-python/VERSION` like on Linux, but this solution here is probably good enough!

Fixes #7