### PR TITLE
Add more packages

### DIFF
--- a/recipes/mne-python_0.24/construct.yaml
+++ b/recipes/mne-python_0.24/construct.yaml
@@ -33,6 +33,8 @@ channels:
 specs:
   - mne ==0.24.1
   - mne-bids =0.9
+  - mne-connectivity =0.2
+  - mne-faster =1.0
   - mne-nirs =0.1
   - python =3.9
   - pip
@@ -50,11 +52,19 @@ specs:
   - ipyvtklink
   - darkdetect
   - qdarkstyle
+  # Helpful for statistics
+  - pingouin
+  # MRI viewer
+  - fsleyes
   # NeuroSpin needs the following packages
   - questionary
   - dcm2niix
   - neurodsp
   - bycycle
+  - fooof
+  - pycircstat
+  - pactools
+  - tensorpac
 
 condarc:
   channels:

--- a/recipes/mne-python_0.24/construct.yaml
+++ b/recipes/mne-python_0.24/construct.yaml
@@ -52,6 +52,9 @@ specs:
   - ipyvtklink
   - darkdetect
   - qdarkstyle
+  # Excel I/O
+  - openpyxl
+  - xlrd
   # Helpful for statistics
   - pingouin
   # MRI viewer

--- a/recipes/mne-python_0.24/construct.yaml
+++ b/recipes/mne-python_0.24/construct.yaml
@@ -36,6 +36,7 @@ specs:
   - mne-connectivity =0.2
   - mne-faster =1.0
   - mne-nirs =0.1
+  - autoreject =0.3
   - python =3.9
   - pip
   - conda


### PR DESCRIPTION
Several of those are still waiting to be merged into conda-forge, so this build will fail for now.

@larsoner @agramfort What's your opinion on including a set of packages commonly used by researchers in our field & scientists we know personally? I generally like the idea of including everything a user would ever need, as long as it doesn't cause us any pain. The installer packages are several 100 MBs in size already anyway, adding another 50 or 100 or even 200 doesn't make much of a difference, right? But where do we draw the line? And: do you have any suggestions for other packages that should be included? In theory, since we're using `conda`, we could even install actual tools like `git`. How far do we want to go? :)

cc @cbrnr @marsipu 